### PR TITLE
V0.1.0

### DIFF
--- a/examples/Example1-GetReadings.py
+++ b/examples/Example1-GetReadings.py
@@ -49,7 +49,7 @@ def runExample():
 	print("\nSparkFun Qwiic Soil Moisture Sensor Example 1\n")
 	mySoilSensor = qwiic_soil_moisture_sensor.QwiicSoilMoistureSensor()
 
-	if mySoilSensor.is_connected == False:
+	if mySoilSensor.is_connected() == False:
 		print("The Qwiic Soil Moisture Sensor device isn't connected to the system. Please check your connection", \
 			file=sys.stderr)
 		return

--- a/examples/Example2-Change_I2C_Address.py
+++ b/examples/Example2-Change_I2C_Address.py
@@ -44,10 +44,13 @@ import qwiic_soil_moisture_sensor
 import time
 import sys
 
+# If you've already changed the I2C address, change this to the current address!
+currentAddress = qwiic_soil_moisture_sensor.SOIL_MOISTURE_SENSOR_DEFAULT_ADDRESS
+
 def runExample():
 
 	print("\nSparkFun Qwiic Soil Moisture Sensor Example 2 - Change I2C Address\n")
-	mySoilSensor = qwiic_soil_moisture_sensor.QwiicSoilMoistureSensor()
+	mySoilSensor = qwiic_soil_moisture_sensor.QwiicSoilMoistureSensor(currentAddress)
 	
 	if mySoilSensor.is_connected() == False:
 		print("The Qwiic Soil Moisture Sensor device isn't connected to the system. Please check your connection", \
@@ -56,17 +59,17 @@ def runExample():
 
 	mySoilSensor.begin()
 		
-	print("\nReady!")
-	print("\nEnter a new I2C address for the Qwiic Soil Moisture Sensor to use.")
-	print("\nDon't use the 0x prefix. For instance if you wanted to")
-	print("\nchange the address to 0x5B, you would type 5B and hit enter.")
-	
+	print("Ready!")
+	print("Enter a new I2C address for the Qwiic Soil Moisture Sensor to use.")
+	print("Any address from 0x08 to 0x3F works.")
+	print("Don't use the 0x prefix. For instance if you wanted to")
+	print("change the address to 0x3B, you would type 3B and hit enter.")
 	
 	newAddress = input("\nNew Address: ")
 	newAddress = int(newAddress, 16)
 
 	# Check if the user entered a valid address
-	if newAddress > 0x08 and newAddress < 0x77:
+	if newAddress >= 0x08 and newAddress <= 0x3F:
 		print("\nCharacters received and new address valid!")
 		print("\nAttempting to set Soil Moisture Sensor address...")
 		

--- a/examples/Example2-Change_I2C_Address.py
+++ b/examples/Example2-Change_I2C_Address.py
@@ -49,9 +49,12 @@ def runExample():
 	print("\nSparkFun Qwiic Soil Moisture Sensor Example 2 - Change I2C Address\n")
 	mySoilSensor = qwiic_soil_moisture_sensor.QwiicSoilMoistureSensor()
 	
-	status = mySoilSensor.begin()
-	if status == False:
-		print ("\nStatus: ", status)
+	if mySoilSensor.is_connected() == False:
+		print("The Qwiic Soil Moisture Sensor device isn't connected to the system. Please check your connection", \
+			file=sys.stderr)
+		return
+
+	mySoilSensor.begin()
 		
 	print("\nReady!")
 	print("\nEnter a new I2C address for the Qwiic Soil Moisture Sensor to use.")

--- a/qwiic_soil_moisture_sensor.py
+++ b/qwiic_soil_moisture_sensor.py
@@ -173,8 +173,8 @@ class QwiicSoilMoistureSensor(object):
             :param newAddress: the new address to set the Soil Moisture Sensor reader to
             :rtype: bool
         """
-            return false
         if newAddress < 0x08 or newAddress > 0x3F:
+            return False
         
         self._i2c.writeByte(self.address, COMMAND_CHANGE_ADDRESS, newAddress)
         

--- a/qwiic_soil_moisture_sensor.py
+++ b/qwiic_soil_moisture_sensor.py
@@ -37,8 +37,8 @@ SOIL_MOISTURE_SENSOR_DEFAULT_ADDRESS = 0x28
 # NOTE: The first address in this list is considered the default I2C address for the
 # device.
 _FULL_ADDRESS_LIST = list(range(0x08,0x77+1))					# Full I2C Address List (excluding resrved addresses)
-_FULL_ADDRESS_LIST.remove(SOIL_MOISTURE_SENSOR_DEFAULT_ADDRESS >> 1) # Remove Default Address of Soil Moisture Sensor from list
-_AVAILABLE_I2C_ADDRESS = [SOIL_MOISTURE_SENSOR_DEFAULT_ADDRESS >> 1]	# Initialize with Default Address of Soil Moisture Sensor
+_FULL_ADDRESS_LIST.remove(SOIL_MOISTURE_SENSOR_DEFAULT_ADDRESS) # Remove Default Address of Soil Moisture Sensor from list
+_AVAILABLE_I2C_ADDRESS = [SOIL_MOISTURE_SENSOR_DEFAULT_ADDRESS]	# Initialize with Default Address of Soil Moisture Sensor
 _AVAILABLE_I2C_ADDRESS.extend(_FULL_ADDRESS_LIST)				# Add Full Range of I2C Addresses
 
 

--- a/qwiic_soil_moisture_sensor.py
+++ b/qwiic_soil_moisture_sensor.py
@@ -36,7 +36,7 @@ SOIL_MOISTURE_SENSOR_DEFAULT_ADDRESS = 0x28
 # Some devices have multiple available addresses - this is a list of these addresses.
 # NOTE: The first address in this list is considered the default I2C address for the
 # device.
-_FULL_ADDRESS_LIST = list(range(0x08,0x77+1))					# Full I2C Address List (excluding resrved addresses)
+_FULL_ADDRESS_LIST = list(range(0x08,0x40))				    	# Full I2C Address List (excluding resrved addresses)
 _FULL_ADDRESS_LIST.remove(SOIL_MOISTURE_SENSOR_DEFAULT_ADDRESS) # Remove Default Address of Soil Moisture Sensor from list
 _AVAILABLE_I2C_ADDRESS = [SOIL_MOISTURE_SENSOR_DEFAULT_ADDRESS]	# Initialize with Default Address of Soil Moisture Sensor
 _AVAILABLE_I2C_ADDRESS.extend(_FULL_ADDRESS_LIST)				# Add Full Range of I2C Addresses
@@ -173,8 +173,8 @@ class QwiicSoilMoistureSensor(object):
             :param newAddress: the new address to set the Soil Moisture Sensor reader to
             :rtype: bool
         """
-        if newAddress < 0x07 or newAddress > 0x78:
             return false
+        if newAddress < 0x08 or newAddress > 0x3F:
         
         self._i2c.writeByte(self.address, COMMAND_CHANGE_ADDRESS, newAddress)
         

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='0.0.2',
+    version='0.1.0',
 
     description='SparkFun Electronics Qwiic Soil Moisture Sensor',
     long_description=long_description,


### PR DESCRIPTION
* Fix default I2C address
* Fix sensor begin in examples
* Limit I2C address range
    * For some reason the ATTiny on the board bricks itself whenever the address is set to anything in the range of `0x40` to `0x77`